### PR TITLE
Expose Screenshot flash and background colors

### DIFF
--- a/packages/SystemUI/res/layout/global_screenshot.xml
+++ b/packages/SystemUI/res/layout/global_screenshot.xml
@@ -19,7 +19,7 @@
     <ImageView android:id="@+id/global_screenshot_background"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:src="@android:color/black"
+        android:src="@color/screenshot_background_color"
         android:visibility="gone" />
     <ImageView android:id="@+id/global_screenshot"
         android:layout_width="wrap_content"
@@ -31,7 +31,7 @@
     <ImageView android:id="@+id/global_screenshot_flash"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:src="@android:color/white"
+        android:src="@color/screenshot_flash_color"
         android:visibility="gone" />
     <com.android.systemui.screenshot.ScreenshotSelectorView
         android:id="@+id/global_screenshot_selector"

--- a/packages/SystemUI/res/values/projekt_colors.xml
+++ b/packages/SystemUI/res/values/projekt_colors.xml
@@ -34,4 +34,7 @@
     <color name="external_qs_tile_tint_color">@android:color/white</color>
     <!-- Keyguard affordance circle background -->
     <color name="keyguard_affordance_circle_background">@android:color/white</color>
+    <!-- Screenshot action colors -->
+    <color name="screenshot_flash_color">@android:color/white</color>
+    <color name="screenshot_background_color">@android:color/black</color>
 </resources>


### PR DESCRIPTION
Keep in mind that Background color already gets 0.5f opacity in the
GlobalScreenshot class (BACKGROUND_ALPHA with some math).
For the flash you can use any color value instead (full opacity or not).

Change-Id: I6ac51358f7f5278d742849ebc49f580554f069cd